### PR TITLE
Updated Broken Sendgrid Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This path can be overridden with an environment variable.
 
 #### Example script files
 
-The following examples are quite basic use cases. For more complicated use cases see the list of examples [here](https://github.com/sendgrid/sendgrid-nodejs/tree/master/use-cases).
+The following examples are quite basic use cases. For more complicated use cases see the list of examples [here](https://github.com/sendgrid/sendgrid-nodejs/tree/main/docs/use-cases).
 
 Sending a single email to a single recipient:
 ```node


### PR DESCRIPTION
The old link to the sendgrid docs is broken - this PR fixes it so that users no longer need to search for the correct location